### PR TITLE
fix: expose complete instance in output and correct instance_global_vars behavior

### DIFF
--- a/modules/ec2/instance.tf
+++ b/modules/ec2/instance.tf
@@ -47,7 +47,7 @@ resource "aws_instance" "test-env-instance" {
   provisioner "remote-exec" {
     inline = concat(
       ["sudo touch /etc/profile.d/global_vars.sh"],
-      [for k, v in var.instance_global_vars : "echo \"${k}=${v}\" >> /etc/profile.d/global_vars.sh"]
+      [for k, v in var.instance_global_vars : "echo \"${k}=${v}\" | sudo tee -a /etc/profile.d/global_vars.sh"]
     )
   }
 
@@ -59,8 +59,4 @@ resource "aws_instance" "test-env-instance" {
   provisioner "remote-exec" {
     script = "${local.setup_path}/setup.sh"
   }
-}
-
-output "ssh_to" {
-  value = var.instance_cnt == 1 ? "${var.user}@${aws_instance.test-env-instance[0].public_ip}" : ""
 }

--- a/modules/ec2/outputs.tf
+++ b/modules/ec2/outputs.tf
@@ -1,3 +1,11 @@
 output "entrypoint" {
   value = var.instance_cnt == 0 ? "" : "ssh ${var.user}@${aws_instance.test-env-instance[0].public_ip} -i ~/.ssh/${var.creator}-${var.test_env_name}-key.pem"
 }
+
+output "instance_info" {
+  value = one(aws_instance.test-env-instance)
+}
+
+output "ssh_to" {
+  value = var.instance_cnt == 1 ? "${var.user}@${aws_instance.test-env-instance[0].public_ip}" : ""
+}


### PR DESCRIPTION

1. Exposes complete instance definition in outputs. This opens the door for at easier cooperation between modules that use this. 
2. `instance_global_vars` were not properly being written to `/etc/profile.d/global_vars.sh`. This fixes that. You still need to source that file in your `setup.sh` script to use these vars though. A generally useful practice is to source `setup.env` first and then `/etc/profile.d/global_vars.sh` so that you can set default values in `setup.env` that you can then over-ride if you have many modules in your `main.tf`