### PR TITLE
feat(ec2): add var for custom ingress rules on sg

### DIFF
--- a/modules/ec2/examples/postgres/main.tf
+++ b/modules/ec2/examples/postgres/main.tf
@@ -12,6 +12,14 @@ module "my-postgres-1" {
   # vpc_id                   = data.terraform_remote_state.vpc.outputs.default-vpc.id    # "CHANGE_ME"
   # subnet_id                = data.terraform_remote_state.vpc.outputs.default-vpc-subnets.0.id # "CHANGE_ME"
   extra_security_group_ids = ["my-sgid"]
+
+  # if you wanted to access postgres directly from your whitelisted IPs...
+  extra_ingress_rules = {
+    "postgresql": {
+      "port": "5432",
+      "protocol": "tcp"  # optional, defaults to "tcp"
+    }
+  }
 }
 
 provider "aws" {

--- a/modules/ec2/security_group.tf
+++ b/modules/ec2/security_group.tf
@@ -45,26 +45,18 @@ resource "aws_security_group" "test-env" {
     ]
   }
 
-  ingress {
-    description = "allow 3000 from listed IPs (for grafana)"
-    from_port   = 3000
-    to_port     = 3000
-    protocol    = "tcp"
-    cidr_blocks = [
-      for ip in var.access_ips :
-      ip
-    ]
-  }
+  dynamic "ingress" {
+    for_each = var.extra_ingress_rules
 
-  ingress {
-    description = "allow 8080 from listed IPs"
-    from_port   = 8080
-    to_port     = 8080
-    protocol    = "tcp"
-    cidr_blocks = [
-      for ip in var.access_ips :
-      ip
-    ]
+    content {
+      from_port   = ingress.value.port
+      to_port     = ingress.value.port
+      protocol    = lookup(ingress.value, "protocol", "tcp")
+      cidr_blocks = [
+        for ip in var.access_ips :
+        ip
+      ]
+    }
   }
 
   egress {

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -89,3 +89,9 @@ variable "setup_path" {
   description = "overwrite the path that contains your setup.sh and ./data directory"
   default     = ""
 }
+
+variable "extra_ingress_rules" {
+  type        = map(any)
+  description = "add custom ingress rules to your security group for accessing apps on custmo ports"
+  default     = {}
+}


### PR DESCRIPTION
# What is this feature

allows users to add custom ingress rules to the security group that's built for the ec2 sandbox via the new `var. extra_ingress_rules`. The variable takes port and protocol inputs and whitelists them for the IPs provided in `var. access_ips`. 

Expected `var. extra_ingress_rules` inputs are a map of rules like so:

```
extra_ingress_rules = {
    "vita": {
      "port": "5173"
    },
    "sqlite": {
      "port": "3000"
    }
  }
```

In this example, the user who creates a sandbox from the ec2 module can make http requests on ports 5173 and 3000 from any of their whitelisted IPs. 

# Motivation

It's a common use case to want to expose services / apps on your sandbox instances to be requested on from your browser etc. 

