### PR TITLE
fix: handle newlines in vars from instance_global_vars

### DIFF
--- a/modules/gcp/vm/instance.tf
+++ b/modules/gcp/vm/instance.tf
@@ -77,7 +77,7 @@ resource "google_compute_instance" "default" {
   provisioner "remote-exec" {
     inline = concat(
       ["sudo touch /etc/profile.d/global_vars.sh"],
-      [for k, v in var.instance_global_vars : "echo \"${k}=${v}\" | sudo tee -a /etc/profile.d/global_vars.sh"]
+      [for k, v in var.instance_global_vars : "printf '%s=\"%s\"\\n' '${k}' '${replace(v, "\n", "\\n")}' | sudo tee -a /etc/profile.d/global_vars.sh"]
     )
   }
 


### PR DESCRIPTION
## What does this PR do?

fixes how the var.instance_global_vars are handled so that newline characters are supported in their values. 

## Motivation

had some use cases where i wanted to capture bash variables for my setup scripts that included newlines, but i preferred to have them in my terraform variables (kept in tf state) rather than hardcoded in files. 

## Limitations

There still might be some use cases that break this, but it seems good enough for now. 

## Testing

I've tested with a local version of this change and it works nicely now where it didn't before. 